### PR TITLE
Suppressing compiler errors

### DIFF
--- a/Yeti/EVTasks/MainTask.cpp
+++ b/Yeti/EVTasks/MainTask.cpp
@@ -30,6 +30,8 @@ extern SPI_HandleTypeDef hspi1;
 extern SPI_HandleTypeDef hspi2;
 #endif
 volatile extern int reset_flags;
+float hard_limit;
+int reset_cause_int;
 
 /// @brief  Possible STM32 system reset causes
 reset_cause_t reset_cause_get(void);

--- a/Yeti/EVTasks/MainTask.h
+++ b/Yeti/EVTasks/MainTask.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-float hard_limit;
+
 
 typedef enum reset_cause_e
 {
@@ -29,7 +29,6 @@ typedef enum reset_cause_e
 	RESET_CAUSE_OPTION_BYTE_LOADER_RESET
 } reset_cause_t;
 
-int reset_cause_int;
 
 void StartMainTask(void *argument);
 


### PR DESCRIPTION
Suppressing linker compiler error by Moving variable definitions from maintask.h file to maintask.cpp file.